### PR TITLE
tests: add a lock for tests with an interrupted transaction.

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,6 +271,8 @@ if (NOT WIN32)
 		file(WRITE ${TEST_DIR}/../devdax.lock "")
 	endif()
 
+	file(WRITE ${TEST_DIR}/../tx_intr.lock "")
+
 	test("tx_intr_pool_regfile" tx_intr_pool_regfile)
 	test("tx_intr_poolset_local_2regfiles" tx_intr_poolset_local_2regfiles)
 	test("tx_intr_poolset_local_regfile" tx_intr_poolset_local_regfile)


### PR DESCRIPTION
Remove timeout from devdax lock.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pmem/pmdk-convert/44)
<!-- Reviewable:end -->
